### PR TITLE
Using non-blocking write

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,18 @@ Logro
 
 ## Introduction
 
-Logro is a log rolling package with page cache control in Go. Inspired by [lumberjack](https://github.com/natefinch/lumberjack)
+Logro is a non-blocking log rolling package with page cache control in Go. Inspired by [lumberjack](https://github.com/natefinch/lumberjack)
 
-Logro is built for high performance:
+Logro is built for high performance (About 50 ns/op):
 
-- __Write with buffer__
+- __Non-blocking Write__
+
+    All write won't be blocked (Just pass a pointer then return).
+    You will never have to worry about the log write stall impacting P999.
+    
+    When the IOPS is unusual high (may caused by bugs or unexpected behavior, e.g. 10 million/s), Logro will overwrite data on writes in lieu of blocking.
+    
+- __Write Combination__
 
     All log data will be written to a user-space buffer first, 
     then flush to the log file.

--- a/config.go
+++ b/config.go
@@ -24,7 +24,7 @@ type Config struct {
 
 	// BufItem is the number of logro's write buffer items,
 	// logro buffers can hold write input up to BufItem.
-	// Default: 2048. 2048 is enough for 1 million IOPS. TODO prove it
+	// Default: 2048. 2048 is enough for 1 million IOPS.
 	//
 	// Buffer will overwrite data on writes in lieu of blocking.
 	// Losing data will be up to BufItem.

--- a/config_test.go
+++ b/config_test.go
@@ -24,7 +24,11 @@ func TestConfigParse(t *testing.T) {
 		t.Fatal("mismatch")
 	}
 
-	if cfg.BufSize != defaultBufSize {
+	if cfg.BufItem != defaultBufItem {
+		t.Fatal("mismatch")
+	}
+
+	if cfg.PerWriteSize != defaultPerWriteSize {
 		t.Fatal("mismatch")
 	}
 
@@ -35,16 +39,16 @@ func TestConfigParse(t *testing.T) {
 
 func TestConfigDevelop(t *testing.T) {
 	cfg := &Config{
-		Developed:   true,
-		MaxSize:     1,
-		BufSize:     2,
-		PerSyncSize: 3,
+		Developed:    true,
+		MaxSize:      1,
+		PerWriteSize: 2,
+		PerSyncSize:  3,
 	}
 	cfg.adjust()
 	if cfg.MaxSize != 1 {
 		t.Fatal("mismatch")
 	}
-	if cfg.BufSize != 2 {
+	if cfg.PerWriteSize != 2 {
 		t.Fatal("mismatch")
 	}
 	if cfg.PerSyncSize != 3 {

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
 module github.com/templexxx/logro
 
-go 1.13
+go 1.14
 
 require (
 	github.com/templexxx/fnc v1.0.0
+	github.com/templexxx/go-diodes v0.0.1
 	go.uber.org/goleak v1.0.0
 	golang.org/x/tools v0.0.0-20200403190813-44a64ad78b9b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/templexxx/fnc v1.0.0 h1:vQwHZP9aMuqu8kRqz0qsNQeSt53ZiRPIg9TGg4JIEiY=
 github.com/templexxx/fnc v1.0.0/go.mod h1:b66A7maDNEAAJOqWNGMJZvlp1VXqWAeeSpFfdeenMHo=
+github.com/templexxx/go-diodes v0.0.1 h1:1m45VIEtQHji1zJJS5vGs/v4dpYJP89LfG/SidEWUyA=
+github.com/templexxx/go-diodes v0.0.1/go.mod h1:VhD34WlqKVOnQtaGiYw0CDrgLQFV47ModMvFP5RgAzY=
 github.com/yuin/goldmark v1.1.27 h1:nqDD4MMMQA0lmWq03Z2/myGPYLQoXtmi0rGVs95ntbo=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.uber.org/goleak v1.0.0 h1:qsup4IcBdlmsnGfqyLl4Ntn3C2XCCuKAE7DwHpScyUo=
@@ -26,12 +28,15 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200226121028-0de0cce0169b h1:0mm1VjtFUOIlE1SbDlwjYaDxZVDP2S5ou6y0gSgXHu8=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20191108193012-7d206e10da11 h1:Yq9t9jnGoR+dBuitxdo9l6Q7xh/zOyNnYUtDKaQ3x0E=

--- a/perf_test.go
+++ b/perf_test.go
@@ -8,138 +8,73 @@
 package logro
 
 import (
-	"flag"
-	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
-	"runtime"
-	"sync"
-	"sync/atomic"
 	"testing"
-	"time"
 )
 
-type perfResult struct {
-	cost   time.Duration
-	submit int64
-	fail   int64
-}
-
-var enablePerfTest bool
-
-func init() {
-	flag.BoolVar(&enablePerfTest, "perf", false, "enable write perf tests")
-}
-
-// TODO test BufItem how many is OK?
-
-func TestWritePerf(t *testing.T) {
-	if !enablePerfTest {
-		t.Skip("skip write perf tests, enable it by adding '-perf=true'")
-	}
-	t.Run("Logro", wrapTestWritePerf(testWritePerf, 128*mb, 256, 64, 16))
-}
-
-func wrapTestWritePerf(f func(*testing.T,
-	int64, int64, int64, int64),
-	total, blockSize, bufSize, perSyncSize int64) func(t *testing.T) {
-
-	return func(t *testing.T) {
-		f(t, total, blockSize, bufSize, perSyncSize)
-	}
-}
-
-// TODO result has P999 P9999
-func testWritePerf(t *testing.T, total, blockSize, bufSize, perSyncSize int64) {
+// This bench is only for non-blocking model,
+// that means all write are same for Write.
+//
+// if there is write stall which will impact user-facing write,
+// it shouldn't use this bench.
+func BenchmarkRotation_Write(b *testing.B) {
 	dir, err := ioutil.TempDir(os.TempDir(), "")
 	if err != nil {
-		t.Fatal(err)
+		b.Fatal(err)
 	}
 	defer os.RemoveAll(dir)
 
-	fn := "logro-perf-test.log"
+	fn := "logro-perf-write-test.log"
 	fp := filepath.Join(dir, fn)
 
 	cfg := new(Config)
 	cfg.OutputPath = fp
-	cfg.PerWriteSize = bufSize
-	cfg.PerSyncSize = perSyncSize
 
 	r, err := New(cfg)
 	if err != nil {
-		t.Fatal(err)
+		b.Fatal(err)
 	}
 	defer r.Close()
 
-	thread := runtime.NumCPU()
-	var size = total / int64(thread)
-	var write func([]byte) (int64, error)
-	write = func(p []byte) (int64, error) {
-		n, err := r.Write(p)
-		return int64(n), err
-	}
-	result := runPerfJob(write, blockSize, size, thread)
-	sec := result.cost.Seconds()
-	bw := float64(size*int64(thread)) / sec
-	iops := float64(result.submit) / sec
-	lat := time.Duration(result.cost.Nanoseconds() / result.submit)
-	//fmt.Printf("config: %#v\n", r.cfg)
-	fmt.Printf("submit: %d, complete: %d, bufsize: %s, blocksize: %s, "+
-		"bandwidth: %s/s, io: %s, avg_iops: %.2f, avg_latency: %s, cost: %s thead: %d\n",
-		result.submit, result.submit-result.fail, byteToStr(float64(cfg.PerWriteSize)), byteToStr(float64(blockSize)),
-		byteToStr(bw), byteToStr(float64(size*int64(thread))), iops, lat, result.cost.String(), thread)
-
-}
-
-func runPerfJob(write func(p []byte) (int64, error), blockSize int64, size int64, thread int) perfResult {
-
-	var failCnt int64
-	p := make([]byte, blockSize)
+	p := make([]byte, 256)
 	rand.Read(p)
-	eachThreadWrites := size / blockSize
 
-	wg := new(sync.WaitGroup)
-	wg.Add(thread)
-
-	start := time.Now()
-
-	for i := 0; i < thread; i++ {
-		go func() {
-			defer wg.Done()
-
-			for j := 0; j < int(eachThreadWrites); j++ {
-				_, err := write(p)
-				if err != nil {
-					atomic.AddInt64(&failCnt, 1)
-				}
-			}
-		}()
-	}
-	wg.Wait()
-
-	cost := time.Now().Sub(start)
-
-	return perfResult{
-		cost:   cost,
-		submit: eachThreadWrites * int64(thread),
-		fail:   failCnt,
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r.Write(p)
 	}
 }
 
-func byteToStr(n float64) string {
-	if n >= float64(mb*1024) {
-		return fmt.Sprintf("%.2fGB", n/float64(mb*1024))
+// Same as BenchmarkRotation_Write.
+func BenchmarkRotation_WriteParallel(b *testing.B) {
+	dir, err := ioutil.TempDir(os.TempDir(), "")
+	if err != nil {
+		b.Fatal(err)
 	}
+	defer os.RemoveAll(dir)
 
-	if n >= float64(mb) {
-		return fmt.Sprintf("%.2fMB", n/float64(mb))
+	fn := "logro-perf-write-test.log"
+	fp := filepath.Join(dir, fn)
+
+	cfg := new(Config)
+	cfg.OutputPath = fp
+
+	r, err := New(cfg)
+	if err != nil {
+		b.Fatal(err)
 	}
+	defer r.Close()
 
-	if n >= float64(kb) {
-		return fmt.Sprintf("%.2fKB", n/float64(kb))
-	}
+	p := make([]byte, 256)
+	rand.Read(p)
 
-	return fmt.Sprintf("%.2fB", n)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			r.Write(p)
+		}
+	})
 }

--- a/perf_test.go
+++ b/perf_test.go
@@ -33,10 +33,12 @@ func init() {
 	flag.BoolVar(&enablePerfTest, "perf", false, "enable write perf tests")
 }
 
+// TODO test BufItem how many is OK?
+
 func TestWritePerf(t *testing.T) {
-	//if !enablePerfTest {
-	//	t.Skip("skip write perf tests, enable it by adding '-perf=true'")
-	//}
+	if !enablePerfTest {
+		t.Skip("skip write perf tests, enable it by adding '-perf=true'")
+	}
 	t.Run("Logro", wrapTestWritePerf(testWritePerf, 128*mb, 256, 64, 16))
 }
 
@@ -49,6 +51,7 @@ func wrapTestWritePerf(f func(*testing.T,
 	}
 }
 
+// TODO result has P999 P9999
 func testWritePerf(t *testing.T, total, blockSize, bufSize, perSyncSize int64) {
 	dir, err := ioutil.TempDir(os.TempDir(), "")
 	if err != nil {
@@ -61,7 +64,7 @@ func testWritePerf(t *testing.T, total, blockSize, bufSize, perSyncSize int64) {
 
 	cfg := new(Config)
 	cfg.OutputPath = fp
-	cfg.BufSize = bufSize
+	cfg.PerWriteSize = bufSize
 	cfg.PerSyncSize = perSyncSize
 
 	r, err := New(cfg)
@@ -85,7 +88,7 @@ func testWritePerf(t *testing.T, total, blockSize, bufSize, perSyncSize int64) {
 	//fmt.Printf("config: %#v\n", r.cfg)
 	fmt.Printf("submit: %d, complete: %d, bufsize: %s, blocksize: %s, "+
 		"bandwidth: %s/s, io: %s, avg_iops: %.2f, avg_latency: %s, cost: %s thead: %d\n",
-		result.submit, result.submit-result.fail, byteToStr(float64(cfg.BufSize)), byteToStr(float64(blockSize)),
+		result.submit, result.submit-result.fail, byteToStr(float64(cfg.PerWriteSize)), byteToStr(float64(blockSize)),
 		byteToStr(bw), byteToStr(float64(size*int64(thread))), iops, lat, result.cost.String(), thread)
 
 }

--- a/perf_test.go
+++ b/perf_test.go
@@ -34,9 +34,9 @@ func init() {
 }
 
 func TestWritePerf(t *testing.T) {
-	if !enablePerfTest {
-		t.Skip("skip write perf tests, enable it by adding '-perf=true'")
-	}
+	//if !enablePerfTest {
+	//	t.Skip("skip write perf tests, enable it by adding '-perf=true'")
+	//}
 	t.Run("Logro", wrapTestWritePerf(testWritePerf, 128*mb, 256, 64, 16))
 }
 
@@ -82,7 +82,7 @@ func testWritePerf(t *testing.T, total, blockSize, bufSize, perSyncSize int64) {
 	bw := float64(size*int64(thread)) / sec
 	iops := float64(result.submit) / sec
 	lat := time.Duration(result.cost.Nanoseconds() / result.submit)
-	fmt.Printf("config: %#v\n", r.cfg)
+	//fmt.Printf("config: %#v\n", r.cfg)
 	fmt.Printf("submit: %d, complete: %d, bufsize: %s, blocksize: %s, "+
 		"bandwidth: %s/s, io: %s, avg_iops: %.2f, avg_latency: %s, cost: %s thead: %d\n",
 		result.submit, result.submit-result.fail, byteToStr(float64(cfg.BufSize)), byteToStr(float64(blockSize)),


### PR DESCRIPTION
All write won't be blocked (Just pass a pointer then return). You will never have to worry about the log write stall impacting P999.
    
When the IOPS is unusual high (may caused by bugs or unexpected behavior, e.g. 10 million/s), Logro will overwrite data on writes in lieu of blocking.